### PR TITLE
Add OSMesa tarball for vispy Travis

### DIFF
--- a/osmesa/README.txt
+++ b/osmesa/README.txt
@@ -1,0 +1,5 @@
+This is a tarball of OSMesa (including GLUT) compiled for Ubuntu 12.04, so
+we can run OSMesa tests on Travis.
+
+The tarball can be built using docker as described in this repository :
+https://github.com/julienr/vispy_osmesa_docker_12_04


### PR DESCRIPTION
As requested by @Eric89GXL in https://github.com/vispy/vispy/pull/1077/files, this adds the osmesa tarball that can be used to run osmesa tests on travis